### PR TITLE
Ability to round up/down in multiply and divide operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ dnum.abs(value); // [100000n, 2]
 
 ### `round(value, optionsOrDecimals)`
 
-Equivalent to the [`Math.round()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round) function, with added option to forcibly round up or down: it returns the value of a number rounded to the nearest integer. 
+Equivalent to the [`Math.round()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round) function, with added option to forcibly round up or down: it returns the value of a number rounded to the nearest integer.
 
 | Name                          | Description                                                                                                        | Type        |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------- |

--- a/README.md
+++ b/README.md
@@ -187,13 +187,13 @@ Alias: `sub()`
 
 Multiply two values together, regardless of their decimals. `decimals` correspond to the decimals desired in the result.
 
-| Name                       | Description                                            | Type        |
-| -------------------------- | ------------------------------------------------------ | ----------- |
-| `value1`                   | First value to multiply                                | `Numberish` |
-| `value2`                   | Second value to multiply                               | `Numberish` |
-| `decimals` (optional)      | Result decimals (defaults to `value1` decimals)        | `number`    |
-| `options.round` (optional) | How to round round results (defaults to `"ROUND_HALF"` | `Decimals`  |
-| returns                    | Result                                                 | `Dnum`      |
+| Name                          | Description                                             | Type        |
+| ----------------------------- | ------------------------------------------------------- | ----------- |
+| `value1`                      | First value to multiply                                 | `Numberish` |
+| `value2`                      | Second value to multiply                                | `Numberish` |
+| `decimals` (optional)         | Result decimals (defaults to `value1` decimals)         | `number`    |
+| `options.rounding` (optional) | How to round round results (defaults to `"ROUND_HALF"`) | `Rounding`  |
+| returns                       | Result                                                  | `Dnum`      |
 
 Alias: `mul()`
 
@@ -212,13 +212,13 @@ let tokenPriceUsd = dnum.multiply(tokenPriceEth, ethPriceUsd, 2); // 570 USD
 
 Divide a value by another one, regardless of their decimals. `decimals` correspond to the decimals desired in the result.
 
-| Name                       | Description                                            | Type        |
-| -------------------------- | ------------------------------------------------------ | ----------- |
-| `value1`                   | Dividend                                               | `Numberish` |
-| `value2`                   | Divisor                                                | `Numberish` |
-| `decimals` (optional)      | Result decimals (defaults to `value1` decimals)        | `number`    |
-| `options.round` (optional) | How to round round results (defaults to `"ROUND_HALF"` | `Decimals`  |
-| returns                    | Result value                                           | `Dnum`      |
+| Name                          | Description                                             | Type        |
+| ----------------------------- | ------------------------------------------------------- | ----------- |
+| `value1`                      | Dividend                                                | `Numberish` |
+| `value2`                      | Divisor                                                 | `Numberish` |
+| `decimals` (optional)         | Result decimals (defaults to `value1` decimals)         | `number`    |
+| `options.rounding` (optional) | How to round round results (defaults to `"ROUND_HALF"`) | `Rounding`  |
+| returns                       | Result value                                            | `Dnum`      |
 
 Alias: `div()`
 
@@ -264,15 +264,16 @@ let value = [-100000n, 2];
 dnum.abs(value); // [100000n, 2]
 ```
 
-### `round(value, decimals)`
+### `round(value, decimals, options)`
 
-Equivalent to the [`Math.round()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round) function: it returns the value of a number rounded to the nearest integer.
+Equivalent to the [`Math.round()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round) function, with added option to forcibly round up or down: it returns the value of a number rounded to the nearest integer. 
 
-| Name                  | Description                                    | Type        |
-| --------------------- | ---------------------------------------------- | ----------- |
-| `value`               | Value to round to the nearest integer          | `Numberish` |
-| `decimals` (optional) | Result decimals (defaults to `value` decimals) | `number`    |
-| returns               | Result value                                   | `Dnum`      |
+| Name                          | Description                                             | Type        |
+| ----------------------------- | ------------------------------------------------------- | ----------- |
+| `value`                       | Value to round to the nearest integer                   | `Numberish` |
+| `decimals` (optional)         | Result decimals (defaults to `value` decimals)          | `number`    |
+| `options.rounding` (optional) | How to round round results (defaults to `"ROUND_HALF"`) | `Rounding`  |
+| returns                       | Result value                                            | `Dnum`      |
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -183,17 +183,17 @@ Subtracts the second value from the first one, regardless of their decimals. dec
 
 Alias: `sub()`
 
-### `multiply(value1, value2, decimals, options)`
+### `multiply(value1, value2, optionsOrDecimals)`
 
-Multiply two values together, regardless of their decimals. `decimals` correspond to the decimals desired in the result.
+Multiply two values together, regardless of their decimals. `options.decimals` correspond to the decimals desired in the result.
 
-| Name                          | Description                                             | Type        |
-| ----------------------------- | ------------------------------------------------------- | ----------- |
-| `value1`                      | First value to multiply                                 | `Numberish` |
-| `value2`                      | Second value to multiply                                | `Numberish` |
-| `decimals` (optional)         | Result decimals (defaults to `value1` decimals)         | `number`    |
-| `options.rounding` (optional) | How to round round results (defaults to `"ROUND_HALF"`) | `Rounding`  |
-| returns                       | Result                                                  | `Dnum`      |
+| Name                          | Description                                                                                                         | Type        |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `value1`                      | First value to multiply                                                                                             | `Numberish` |
+| `value2`                      | Second value to multiply                                                                                            | `Numberish` |
+| `options.decimals` (optional) | Results decimals (defaults to `value1` decimals). Setting `options` to a `number` acts as an alias for this option. | `Decimals`  |
+| `options.rounding` (optional) | How to round round results (defaults to `"ROUND_HALF"`)                                                             | `Rounding`  |
+| returns                       | Result                                                                                                              | `Dnum`      |
 
 Alias: `mul()`
 
@@ -208,17 +208,17 @@ let tokenPriceUsd = dnum.multiply(tokenPriceEth, ethPriceUsd, 2); // 570 USD
 // tokenPriceUsd equals [57000, 2]
 ```
 
-### `divide(value1, value2, decimals, options)`
+### `divide(value1, value2, optionsOrDecimals)`
 
-Divide a value by another one, regardless of their decimals. `decimals` correspond to the decimals desired in the result.
+Divide a value by another one, regardless of their decimals. `options.decimals` correspond to the decimals desired in the result.
 
-| Name                          | Description                                             | Type        |
-| ----------------------------- | ------------------------------------------------------- | ----------- |
-| `value1`                      | Dividend                                                | `Numberish` |
-| `value2`                      | Divisor                                                 | `Numberish` |
-| `decimals` (optional)         | Result decimals (defaults to `value1` decimals)         | `number`    |
-| `options.rounding` (optional) | How to round round results (defaults to `"ROUND_HALF"`) | `Rounding`  |
-| returns                       | Result value                                            | `Dnum`      |
+| Name                          | Description                                                                                                         | Type        |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `value1`                      | Dividend                                                                                                            | `Numberish` |
+| `value2`                      | Divisor                                                                                                             | `Numberish` |
+| `options.decimals` (optional) | Results decimals (defaults to `value1` decimals). Setting `options` to a `number` acts as an alias for this option. | `Decimals`  |
+| `options.rounding` (optional) | How to round round results (defaults to `"ROUND_HALF"`)                                                             | `Rounding`  |
+| returns                       | Result                                                                                                              | `Dnum`      |
 
 Alias: `div()`
 
@@ -264,16 +264,16 @@ let value = [-100000n, 2];
 dnum.abs(value); // [100000n, 2]
 ```
 
-### `round(value, decimals, options)`
+### `round(value, optionsOrDecimals)`
 
 Equivalent to the [`Math.round()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round) function, with added option to forcibly round up or down: it returns the value of a number rounded to the nearest integer. 
 
-| Name                          | Description                                             | Type        |
-| ----------------------------- | ------------------------------------------------------- | ----------- |
-| `value`                       | Value to round to the nearest integer                   | `Numberish` |
-| `decimals` (optional)         | Result decimals (defaults to `value` decimals)          | `number`    |
-| `options.rounding` (optional) | How to round round results (defaults to `"ROUND_HALF"`) | `Rounding`  |
-| returns                       | Result value                                            | `Dnum`      |
+| Name                          | Description                                                                                                        | Type        |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------- |
+| `value`                       | Value to round to the nearest integer                                                                              | `Numberish` |
+| `options.decimals` (optional) | Results decimals (defaults to `value` decimals). Setting `options` to a `number` acts as an alias for this option. | `Decimals`  |
+| `options.rounding` (optional) | How to round round results (defaults to `"ROUND_HALF"`)                                                            | `Rounding`  |
+| returns                       | Result                                                                                                             | `Dnum`      |
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -183,16 +183,17 @@ Subtracts the second value from the first one, regardless of their decimals. dec
 
 Alias: `sub()`
 
-### `multiply(value1, value2, decimals)`
+### `multiply(value1, value2, decimals, options)`
 
 Multiply two values together, regardless of their decimals. `decimals` correspond to the decimals desired in the result.
 
-| Name                  | Description                                     | Type        |
-| --------------------- | ----------------------------------------------- | ----------- |
-| `value1`              | First value to multiply                         | `Numberish` |
-| `value2`              | Second value to multiply                        | `Numberish` |
-| `decimals` (optional) | Result decimals (defaults to `value1` decimals) | `number`    |
-| returns               | Result                                          | `Dnum`      |
+| Name                       | Description                                            | Type        |
+| -------------------------- | ------------------------------------------------------ | ----------- |
+| `value1`                   | First value to multiply                                | `Numberish` |
+| `value2`                   | Second value to multiply                               | `Numberish` |
+| `decimals` (optional)      | Result decimals (defaults to `value1` decimals)        | `number`    |
+| `options.round` (optional) | How to round round results (defaults to `"ROUND_HALF"` | `Decimals`  |
+| returns                    | Result                                                 | `Dnum`      |
 
 Alias: `mul()`
 
@@ -207,16 +208,17 @@ let tokenPriceUsd = dnum.multiply(tokenPriceEth, ethPriceUsd, 2); // 570 USD
 // tokenPriceUsd equals [57000, 2]
 ```
 
-### `divide(value1, value2, decimals)`
+### `divide(value1, value2, decimals, options)`
 
 Divide a value by another one, regardless of their decimals. `decimals` correspond to the decimals desired in the result.
 
-| Name                  | Description                                     | Type        |
-| --------------------- | ----------------------------------------------- | ----------- |
-| `value1`              | Dividend                                        | `Numberish` |
-| `value2`              | Divisor                                         | `Numberish` |
-| `decimals` (optional) | Result decimals (defaults to `value1` decimals) | `number`    |
-| returns               | Result value                                    | `Dnum`      |
+| Name                       | Description                                            | Type        |
+| -------------------------- | ------------------------------------------------------ | ----------- |
+| `value1`                   | Dividend                                               | `Numberish` |
+| `value2`                   | Divisor                                                | `Numberish` |
+| `decimals` (optional)      | Result decimals (defaults to `value1` decimals)        | `number`    |
+| `options.round` (optional) | How to round round results (defaults to `"ROUND_HALF"` | `Decimals`  |
+| returns                    | Result value                                           | `Dnum`      |
 
 Alias: `div()`
 
@@ -471,12 +473,12 @@ let dnum = fromJSON("[\"123456789000000000000\", 18]");
 
 Return a new `Dnum` with a different amount of decimals. The value will reflect this change so that the represented number stays the same.
 
-| Name            | Description                                                                         | Type      |
-| --------------- | ----------------------------------------------------------------------------------- | --------- |
-| `value`         | The number from which decimals will be changed                                      | `Dnum`    |
-| `decimals`      | New number of decimals                                                              | `number`  |
-| `options.round` | In case of reduction, whether to round the remaining decimals (defaults to `true`). | `boolean` |
-| returns         | Result value                                                                        | `Dnum`    |
+| Name            | Description                                                                                 | Type      |
+| --------------- | ------------------------------------------------------------------------------------------- | --------- |
+| `value`         | The number from which decimals will be changed                                              | `Dnum`    |
+| `decimals`      | New number of decimals                                                                      | `number`  |
+| `options.round` | In case of reduction, whether to round the remaining decimals (defaults to `"ROUND_HALF"`). | `Decimals` |
+| returns         | Result value                                                                                | `Dnum`    |
 
 Note: `from(value, decimals)` can also be used instead.
 

--- a/README.md
+++ b/README.md
@@ -474,12 +474,12 @@ let dnum = fromJSON("[\"123456789000000000000\", 18]");
 
 Return a new `Dnum` with a different amount of decimals. The value will reflect this change so that the represented number stays the same.
 
-| Name            | Description                                                                                 | Type      |
-| --------------- | ------------------------------------------------------------------------------------------- | --------- |
-| `value`         | The number from which decimals will be changed                                              | `Dnum`    |
-| `decimals`      | New number of decimals                                                                      | `number`  |
-| `options.round` | In case of reduction, whether to round the remaining decimals (defaults to `"ROUND_HALF"`). | `Decimals` |
-| returns         | Result value                                                                                | `Dnum`    |
+| Name            | Description                                                                                 | Type       |
+| --------------- | ------------------------------------------------------------------------------------------- | ---------- |
+| `value`         | The number from which decimals will be changed                                              | `Dnum`     |
+| `decimals`      | New number of decimals                                                                      | `number`   |
+| `options.round` | In case of reduction, whether to round the remaining decimals (defaults to `"ROUND_HALF"`). | `Rounding` |
+| returns         | Result value                                                                                | `Dnum`     |
 
 Note: `from(value, decimals)` can also be used instead.
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -29,7 +29,7 @@ import {
   subtract,
 } from "./operations";
 
-export type { Decimals, Dnum, Numberish, Value } from "./types";
+export type { Decimals, Dnum, Numberish, Rounding, Value } from "./types";
 
 export {
   abs,

--- a/src/dnum.ts
+++ b/src/dnum.ts
@@ -1,4 +1,11 @@
-import type { Decimals, Rounding, Dnum, Numberish, Value } from "./types";
+import type {
+  AliasedOptions,
+  Decimals,
+  Dnum,
+  Numberish,
+  Rounding,
+  Value,
+} from "./types";
 
 import fromExponential from "from-exponential";
 import {
@@ -130,13 +137,11 @@ export function fromJSON(jsonValue: string): Dnum {
 
 export function toParts(
   dnum: Dnum,
-  optionsOrDigits:
-    | {
-      digits?: number; // defaults to decimals
-      trailingZeros?: boolean;
-      decimalsRounding?: Rounding
-    }
-    | number = {},
+  optionsOrDigits: AliasedOptions<{
+    digits?: number; // defaults to decimals
+    trailingZeros?: boolean;
+    decimalsRounding?: Rounding;
+  }, "digits"> = {},
 ): [
   whole: bigint, // always positive
   fraction: string | null,

--- a/src/dnum.ts
+++ b/src/dnum.ts
@@ -76,16 +76,16 @@ export function from(
 export function setValueDecimals(
   value: Value,
   decimalsDiff: Decimals,
-  options: { round?: Rounding } = {},
+  options: { rounding?: Rounding } = {},
 ): Value {
-  options.round ??= "ROUND_HALF";
+  options.rounding ??= "ROUND_HALF";
 
   if (decimalsDiff > 0) {
     return value * powerOfTen(decimalsDiff);
   }
 
   if (decimalsDiff < 0) {
-    return divideAndRound(value, powerOfTen(-decimalsDiff), options.round)
+    return divideAndRound(value, powerOfTen(-decimalsDiff), options.rounding);
   }
 
   return value;
@@ -94,9 +94,9 @@ export function setValueDecimals(
 export function setDecimals(
   value: Dnum,
   decimals: Decimals,
-  options: { round?: Rounding } = {},
+  options: { rounding?: Rounding } = {},
 ): Dnum {
-  options.round ??= "ROUND_HALF";
+  options.rounding ??= "ROUND_HALF";
 
   if (value[1] === decimals) {
     return value;

--- a/src/dnum.ts
+++ b/src/dnum.ts
@@ -1,4 +1,4 @@
-import type { Decimals, Dnum, Numberish, Value } from "./types";
+import type { Decimals, Rounding, Dnum, Numberish, Value } from "./types";
 
 import fromExponential from "from-exponential";
 import {
@@ -76,18 +76,16 @@ export function from(
 export function setValueDecimals(
   value: Value,
   decimalsDiff: Decimals,
-  options: { round?: boolean } = {},
+  options: { round?: Rounding } = {},
 ): Value {
-  options.round ??= true;
+  options.round ??= "ROUND_HALF";
 
   if (decimalsDiff > 0) {
     return value * powerOfTen(decimalsDiff);
   }
 
   if (decimalsDiff < 0) {
-    return options.round
-      ? divideAndRound(value, powerOfTen(-decimalsDiff))
-      : value / powerOfTen(-decimalsDiff);
+    return divideAndRound(value, powerOfTen(-decimalsDiff), options.round)
   }
 
   return value;
@@ -96,9 +94,9 @@ export function setValueDecimals(
 export function setDecimals(
   value: Dnum,
   decimals: Decimals,
-  options: { round?: boolean } = {},
+  options: { round?: Rounding } = {},
 ): Dnum {
-  options.round ??= true;
+  options.round ??= "ROUND_HALF";
 
   if (value[1] === decimals) {
     return value;
@@ -136,7 +134,7 @@ export function toParts(
     | {
       digits?: number; // defaults to decimals
       trailingZeros?: boolean;
-      decimalsRounding?: "ROUND_HALF" | "ROUND_UP" | "ROUND_DOWN";
+      decimalsRounding?: Rounding
     }
     | number = {},
 ): [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export type { Decimals, Dnum, Numberish, Value } from "./api";
+export type { Decimals, Dnum, Numberish, Rounding, Value } from "./api";
 export * from "./api";

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -77,12 +77,15 @@ export function divide(
   if (num2_[0] === 0n) {
     throw new Error("dnum: division by zero");
   }
-  const value1 = setValueDecimals(num1_[0], Math.max(num1_[1], options.decimals ?? 0));
+  const value1 = setValueDecimals(
+    num1_[0],
+    Math.max(num1_[1], options.decimals ?? 0),
+  );
   const value2 = setValueDecimals(num2_[0], 0);
   return setDecimals(
     [divideAndRound(value1, value2, options.rounding), num1_[1]],
     options.decimals ?? (isDnum(num1) ? num1[1] : num1_[1]),
-    { rounding: options.rounding }
+    { rounding: options.rounding },
   );
 }
 

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -37,13 +37,13 @@ export function multiply(
   num1: Numberish,
   num2: Numberish,
   decimals?: Decimals,
-  round: Rounding = "ROUND_HALF",
+  rounding: Rounding = "ROUND_HALF",
 ): Dnum {
   const [num1_, num2_] = normalizePairAndDecimals(num1, num2, decimals);
   return setDecimals(
     [num1_[0] * num2_[0], num1_[1] * 2],
     decimals ?? (isDnum(num1) ? num1[1] : num1_[1]),
-    { round }
+    { rounding }
   );
 }
 
@@ -51,7 +51,7 @@ export function divide(
   num1: Numberish,
   num2: Numberish,
   decimals?: Decimals,
-  round: Rounding = "ROUND_HALF",
+  rounding: Rounding = "ROUND_HALF",
 ): Dnum {
   const [num1_, num2_] = normalizePairAndDecimals(num1, num2, decimals);
   if (num2_[0] === 0n) {
@@ -60,9 +60,9 @@ export function divide(
   const value1 = setValueDecimals(num1_[0], Math.max(num1_[1], decimals ?? 0));
   const value2 = setValueDecimals(num2_[0], 0);
   return setDecimals(
-    [divideAndRound(value1, value2, round), num1_[1]],
+    [divideAndRound(value1, value2, rounding), num1_[1]],
     decimals ?? (isDnum(num1) ? num1[1] : num1_[1]),
-    { round }
+    { rounding }
   );
 }
 
@@ -132,10 +132,14 @@ export function ceil(num: Numberish, decimals?: Decimals): Dnum {
   return multiply(floor(multiply(num, minus1)), minus1, decimals);
 }
 
-export function round(num: Numberish, decimals?: Decimals): Dnum {
+export function round(
+  num: Numberish, 
+  decimals?: Decimals,
+  rounding: Rounding = "ROUND_HALF",
+): Dnum {
   const numIn = from(num);
   return setDecimals(
-    setDecimals(numIn, 0), // setDecimals() uses divideAndRound() internally
+    setDecimals(numIn, 0, { rounding }), // setDecimals() uses divideAndRound() internally
     decimals === undefined ? numIn[1] : decimals,
   );
 }

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -1,4 +1,4 @@
-import type { Decimals, Dnum, Numberish } from "./types";
+import type { Decimals, Dnum, Numberish, Rounding } from "./types";
 
 import {
   equalizeDecimals,
@@ -37,11 +37,13 @@ export function multiply(
   num1: Numberish,
   num2: Numberish,
   decimals?: Decimals,
+  round: Rounding = "ROUND_HALF",
 ): Dnum {
   const [num1_, num2_] = normalizePairAndDecimals(num1, num2, decimals);
   return setDecimals(
     [num1_[0] * num2_[0], num1_[1] * 2],
     decimals ?? (isDnum(num1) ? num1[1] : num1_[1]),
+    { round }
   );
 }
 
@@ -49,6 +51,7 @@ export function divide(
   num1: Numberish,
   num2: Numberish,
   decimals?: Decimals,
+  round: Rounding = "ROUND_HALF",
 ): Dnum {
   const [num1_, num2_] = normalizePairAndDecimals(num1, num2, decimals);
   if (num2_[0] === 0n) {
@@ -57,8 +60,9 @@ export function divide(
   const value1 = setValueDecimals(num1_[0], Math.max(num1_[1], decimals ?? 0));
   const value2 = setValueDecimals(num2_[0], 0);
   return setDecimals(
-    [divideAndRound(value1, value2), num1_[1]],
+    [divideAndRound(value1, value2, round), num1_[1]],
     decimals ?? (isDnum(num1) ? num1[1] : num1_[1]),
+    { round }
   );
 }
 

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -111,25 +111,11 @@ export function abs(num: Numberish, decimals?: Decimals): Dnum {
 }
 
 export function floor(num: Numberish, decimals?: Decimals): Dnum {
-  const [valueIn, decimalsIn] = from(num);
-  if (decimals === undefined) decimals = decimalsIn;
-
-  let whole = BigInt(String(valueIn).slice(0, -decimalsIn));
-  const fraction = BigInt(String(valueIn).slice(-decimalsIn));
-  if (whole < 0n && fraction > 0n) {
-    whole -= 1n;
-  }
-  const numFloored: Dnum = [
-    BigInt(String(whole) + "0".repeat(decimalsIn)),
-    decimalsIn,
-  ];
-
-  return setDecimals(numFloored, decimals);
+  return round(num, decimals, "ROUND_DOWN");
 }
 
 export function ceil(num: Numberish, decimals?: Decimals): Dnum {
-  const minus1: Dnum = [-1n, 0];
-  return multiply(floor(multiply(num, minus1)), minus1, decimals);
+  return round(num, decimals, "ROUND_UP");
 }
 
 export function round(

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -40,8 +40,8 @@ export function multiply(
 ): Dnum {
   const options = typeof optionsOrDecimals === "number"
     ? { decimals: optionsOrDecimals }
-    : optionsOrDecimals
-  options.rounding ??= "ROUND_HALF"
+    : optionsOrDecimals;
+  options.rounding ??= "ROUND_HALF";
 
   const [num1_, num2_] = normalizePairAndDecimals(num1, num2, options.decimals);
   return setDecimals(
@@ -57,9 +57,9 @@ export function divide(
   optionsOrDecimals: OptionsOrDecimals = {},
 ): Dnum {
   const options = typeof optionsOrDecimals === "number"
-  ? { decimals: optionsOrDecimals }
-  : optionsOrDecimals
-  options.rounding ??= "ROUND_HALF"
+    ? { decimals: optionsOrDecimals }
+    : optionsOrDecimals;
+  options.rounding ??= "ROUND_HALF";
 
   const [num1_, num2_] = normalizePairAndDecimals(num1, num2, options.decimals);
   if (num2_[0] === 0n) {
@@ -132,8 +132,8 @@ export function round(
 ): Dnum {
   const options = typeof optionsOrDecimals === "number"
     ? { decimals: optionsOrDecimals }
-    : optionsOrDecimals
-  options.rounding ??= "ROUND_HALF"
+    : optionsOrDecimals;
+  options.rounding ??= "ROUND_HALF";
 
   const numIn = from(num);
   return setDecimals(

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -1,4 +1,4 @@
-import type { Decimals, Dnum, Numberish, Rounding } from "./types";
+import type { Decimals, Dnum, Numberish, OptionsOrDecimals } from "./types";
 
 import {
   equalizeDecimals,
@@ -36,33 +36,41 @@ export function subtract(
 export function multiply(
   num1: Numberish,
   num2: Numberish,
-  decimals?: Decimals,
-  rounding: Rounding = "ROUND_HALF",
+  optionsOrDecimals: OptionsOrDecimals = {},
 ): Dnum {
-  const [num1_, num2_] = normalizePairAndDecimals(num1, num2, decimals);
+  const options = typeof optionsOrDecimals === "number"
+    ? { decimals: optionsOrDecimals }
+    : optionsOrDecimals
+  options.rounding ??= "ROUND_HALF"
+
+  const [num1_, num2_] = normalizePairAndDecimals(num1, num2, options.decimals);
   return setDecimals(
     [num1_[0] * num2_[0], num1_[1] * 2],
-    decimals ?? (isDnum(num1) ? num1[1] : num1_[1]),
-    { rounding }
+    options.decimals ?? (isDnum(num1) ? num1[1] : num1_[1]),
+    { rounding: options.rounding }
   );
 }
 
 export function divide(
   num1: Numberish,
   num2: Numberish,
-  decimals?: Decimals,
-  rounding: Rounding = "ROUND_HALF",
+  optionsOrDecimals: OptionsOrDecimals = {},
 ): Dnum {
-  const [num1_, num2_] = normalizePairAndDecimals(num1, num2, decimals);
+  const options = typeof optionsOrDecimals === "number"
+  ? { decimals: optionsOrDecimals }
+  : optionsOrDecimals
+  options.rounding ??= "ROUND_HALF"
+
+  const [num1_, num2_] = normalizePairAndDecimals(num1, num2, options.decimals);
   if (num2_[0] === 0n) {
     throw new Error("dnum: division by zero");
   }
-  const value1 = setValueDecimals(num1_[0], Math.max(num1_[1], decimals ?? 0));
+  const value1 = setValueDecimals(num1_[0], Math.max(num1_[1], options.decimals ?? 0));
   const value2 = setValueDecimals(num2_[0], 0);
   return setDecimals(
-    [divideAndRound(value1, value2, rounding), num1_[1]],
-    decimals ?? (isDnum(num1) ? num1[1] : num1_[1]),
-    { rounding }
+    [divideAndRound(value1, value2, options.rounding), num1_[1]],
+    options.decimals ?? (isDnum(num1) ? num1[1] : num1_[1]),
+    { rounding: options.rounding }
   );
 }
 
@@ -111,22 +119,26 @@ export function abs(num: Numberish, decimals?: Decimals): Dnum {
 }
 
 export function floor(num: Numberish, decimals?: Decimals): Dnum {
-  return round(num, decimals, "ROUND_DOWN");
+  return round(num, { decimals, rounding: "ROUND_DOWN" });
 }
 
 export function ceil(num: Numberish, decimals?: Decimals): Dnum {
-  return round(num, decimals, "ROUND_UP");
+  return round(num, { decimals, rounding: "ROUND_UP" });
 }
 
 export function round(
   num: Numberish, 
-  decimals?: Decimals,
-  rounding: Rounding = "ROUND_HALF",
+  optionsOrDecimals: OptionsOrDecimals = {},
 ): Dnum {
+  const options = typeof optionsOrDecimals === "number"
+    ? { decimals: optionsOrDecimals }
+    : optionsOrDecimals
+  options.rounding ??= "ROUND_HALF"
+
   const numIn = from(num);
   return setDecimals(
-    setDecimals(numIn, 0, { rounding }), // setDecimals() uses divideAndRound() internally
-    decimals === undefined ? numIn[1] : decimals,
+    setDecimals(numIn, 0, { rounding: options.rounding }), // setDecimals() uses divideAndRound() internally
+    options.decimals === undefined ? numIn[1] : options.decimals,
   );
 }
 

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -1,4 +1,10 @@
-import type { Decimals, Dnum, Numberish, OptionsOrDecimals } from "./types";
+import type {
+  AliasedOptions,
+  Decimals,
+  Dnum,
+  Numberish,
+  Rounding,
+} from "./types";
 
 import {
   equalizeDecimals,
@@ -36,7 +42,10 @@ export function subtract(
 export function multiply(
   num1: Numberish,
   num2: Numberish,
-  optionsOrDecimals: OptionsOrDecimals = {},
+  optionsOrDecimals: AliasedOptions<{
+    decimals?: Decimals;
+    rounding?: Rounding;
+  }, "decimals"> = {},
 ): Dnum {
   const options = typeof optionsOrDecimals === "number"
     ? { decimals: optionsOrDecimals }
@@ -47,14 +56,17 @@ export function multiply(
   return setDecimals(
     [num1_[0] * num2_[0], num1_[1] * 2],
     options.decimals ?? (isDnum(num1) ? num1[1] : num1_[1]),
-    { rounding: options.rounding }
+    { rounding: options.rounding },
   );
 }
 
 export function divide(
   num1: Numberish,
   num2: Numberish,
-  optionsOrDecimals: OptionsOrDecimals = {},
+  optionsOrDecimals: AliasedOptions<{
+    decimals?: Decimals;
+    rounding?: Rounding;
+  }, "decimals"> = {},
 ): Dnum {
   const options = typeof optionsOrDecimals === "number"
     ? { decimals: optionsOrDecimals }
@@ -127,8 +139,11 @@ export function ceil(num: Numberish, decimals?: Decimals): Dnum {
 }
 
 export function round(
-  num: Numberish, 
-  optionsOrDecimals: OptionsOrDecimals = {},
+  num: Numberish,
+  optionsOrDecimals: AliasedOptions<{
+    decimals?: Decimals;
+    rounding?: Rounding;
+  }, "decimals"> = {},
 ): Dnum {
   const options = typeof optionsOrDecimals === "number"
     ? { decimals: optionsOrDecimals }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type Numberish = bigint | number | string | Dnum;
 export type Value = bigint;
 export type Decimals = number;
+export type Rounding = "ROUND_HALF" | "ROUND_UP" | "ROUND_DOWN";
 export type Dnum = readonly [value: Value, decimals: Decimals];

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,3 +3,8 @@ export type Value = bigint;
 export type Decimals = number;
 export type Rounding = "ROUND_HALF" | "ROUND_UP" | "ROUND_DOWN";
 export type Dnum = readonly [value: Value, decimals: Decimals];
+
+export type OptionsOrDecimals = Decimals | {
+  decimals?: Decimals;
+  rounding?: Rounding;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,12 @@
-export type Numberish = bigint | number | string | Dnum;
-export type Value = bigint;
 export type Decimals = number;
-export type Rounding = "ROUND_HALF" | "ROUND_UP" | "ROUND_DOWN";
 export type Dnum = readonly [value: Value, decimals: Decimals];
+export type Numberish = bigint | number | string | Dnum;
+export type Rounding = "ROUND_HALF" | "ROUND_UP" | "ROUND_DOWN";
+export type Value = bigint;
 
-export type OptionsOrDecimals = Decimals | {
-  decimals?: Decimals;
-  rounding?: Rounding;
-};
+export type AliasedOptions<
+  Options extends Record<string, unknown>,
+  AliasName extends keyof Options,
+> =
+  | Options
+  | Options[AliasName];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,38 @@
-export function divideAndRound(dividend: bigint, divisor: bigint) {
-  const invertSign = dividend < 0n ? -1n : 1n;
-  return (dividend * invertSign + divisor / 2n) / divisor * invertSign;
+import { Rounding } from "./types";
+
+function divideAndRoundUp(dividend: bigint, divisor: bigint) {
+  const num = divisor > 0n ? dividend : -dividend;
+  const den = divisor > 0n ? divisor : -divisor;
+  const remainder = num % den;
+  const roundUp = remainder > 0n ? 1n : 0n;
+  return num / den + roundUp;
+}
+
+function divideAndRoundDown(dividend: bigint, divisor: bigint) {
+  const num = divisor > 0n ? dividend : -dividend;
+  const den = divisor > 0n ? divisor : -divisor;
+  const remainder = num % den;
+  const roundDown = remainder < 0n ? -1n : 0n;
+  return num / den + roundDown;
+}
+
+function divideAndRoundHalf(dividend: bigint, divisor: bigint) {
+  const num = divisor > 0n ? dividend : -dividend;
+  const den = divisor > 0n ? divisor : -divisor;
+  const invertSign = num < 0n ? -1n : 1n;
+  return (num * invertSign + den / 2n) / den * invertSign;
+}
+
+export function divideAndRound(
+  dividend: bigint,
+  divisor: bigint,
+  rounding: Rounding = "ROUND_HALF"
+) {
+  return rounding === "ROUND_UP" 
+    ? divideAndRoundUp(dividend, divisor) 
+    : rounding === "ROUND_DOWN"
+    ? divideAndRoundDown(dividend, divisor)
+    : divideAndRoundHalf(dividend, divisor);
 }
 
 export function splitNumber(number: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,10 +26,10 @@ function divideAndRoundHalf(dividend: bigint, divisor: bigint) {
 export function divideAndRound(
   dividend: bigint,
   divisor: bigint,
-  rounding: Rounding = "ROUND_HALF"
+  rounding: Rounding = "ROUND_HALF",
 ) {
-  return rounding === "ROUND_UP" 
-    ? divideAndRoundUp(dividend, divisor) 
+  return rounding === "ROUND_UP"
+    ? divideAndRoundUp(dividend, divisor)
     : rounding === "ROUND_DOWN"
     ? divideAndRoundDown(dividend, divisor)
     : divideAndRoundHalf(dividend, divisor);

--- a/test/all.test.ts
+++ b/test/all.test.ts
@@ -59,16 +59,16 @@ describe("setValueDecimals()", () => {
     expect(setValueDecimals(123456n, 0)).toBe(123456n);
   });
   it("round decimals up when specified and decreasing", () => {
-    expect(setValueDecimals(1234n, -2, { round: "ROUND_UP" })).toBe(13n);
-    expect(setValueDecimals(123456n, -2, { round: "ROUND_UP" })).toBe(1235n);
-    expect(setValueDecimals(-1234n, -2, { round: "ROUND_UP" })).toBe(-12n);
-    expect(setValueDecimals(-123456n, -2, { round: "ROUND_UP" })).toBe(-1234n);
+    expect(setValueDecimals(1234n, -2, { rounding: "ROUND_UP" })).toBe(13n);
+    expect(setValueDecimals(123456n, -2, { rounding: "ROUND_UP" })).toBe(1235n);
+    expect(setValueDecimals(-1234n, -2, { rounding: "ROUND_UP" })).toBe(-12n);
+    expect(setValueDecimals(-123456n, -2, { rounding: "ROUND_UP" })).toBe(-1234n);
   });
-  it("round decimals down when specified and specified", () => {
-    expect(setValueDecimals(1234n, -2, { round: "ROUND_DOWN" })).toBe(12n);
-    expect(setValueDecimals(123456n, -2, { round: "ROUND_DOWN" })).toBe(1234n);
-    expect(setValueDecimals(-1234n, -2, { round: "ROUND_DOWN" })).toBe(-13n);
-    expect(setValueDecimals(-123456n, -2, { round: "ROUND_DOWN" })).toBe(-1235n);
+  it("round decimals down when specified and decreasing", () => {
+    expect(setValueDecimals(1234n, -2, { rounding: "ROUND_DOWN" })).toBe(12n);
+    expect(setValueDecimals(123456n, -2, { rounding: "ROUND_DOWN" })).toBe(1234n);
+    expect(setValueDecimals(-1234n, -2, { rounding: "ROUND_DOWN" })).toBe(-13n);
+    expect(setValueDecimals(-123456n, -2, { rounding: "ROUND_DOWN" })).toBe(-1235n);
   });
 });
 
@@ -88,6 +88,12 @@ describe("setDecimals()", () => {
   it("throws if decimals are negative", () => {
     expect(() => setDecimals([123456n, -4], 4)).toThrowError("negative");
     expect(() => setDecimals([123456n, 4], -4)).toThrowError("negative");
+  });
+  it("round decimals up when specified and decreasing", () => {
+    expect(setDecimals([1234n, 2], 1, { rounding: "ROUND_UP" })).toEqual([124n, 1]);
+  });
+  it("round decimals down when specified and decreasing", () => {
+    expect(setDecimals([123456n, 2], 1, { rounding: "ROUND_DOWN" })).toEqual([12345n, 1]);
   });
 });
 
@@ -472,7 +478,7 @@ describe("compare()", () => {
 });
 
 describe("round()", () => {
-  it("works", () => {
+  it("rounds decimals", () => {
     expect(round([1000n, 2])).toEqual([1000n, 2]);
     expect(round([123456n, 2])).toEqual([123500n, 2]);
     expect(round([123449n, 2])).toEqual([123400n, 2]);
@@ -485,6 +491,38 @@ describe("round()", () => {
     ).toEqual([1234000000000000000000n, 18]);
     expect(
       round([1234499999999999999999n, 18], 2),
+    ).toEqual([123400n, 2]);
+  });
+
+  it("rounds decimals up", () => {
+    expect(round([1000n, 2], undefined, "ROUND_UP")).toEqual([1000n, 2]);
+    expect(round([123456n, 2], undefined, "ROUND_UP")).toEqual([123500n, 2]);
+    expect(round([123449n, 2], undefined, "ROUND_UP")).toEqual([123500n, 2]);
+    expect(round([123450n, 2], undefined, "ROUND_UP")).toEqual([123500n, 2]);
+    expect(
+      round([1234555555555555555555n, 18], undefined, "ROUND_UP"),
+    ).toEqual([1235000000000000000000n, 18]);
+    expect(
+      round([1234499999999999999999n, 18], undefined, "ROUND_UP"),
+    ).toEqual([1235000000000000000000n, 18]);
+    expect(
+      round([1234499999999999999999n, 18], 2, "ROUND_UP"),
+    ).toEqual([123500n, 2]);
+  });
+
+  it("rounds decimals down", () => {
+    expect(round([1000n, 2], undefined, "ROUND_DOWN")).toEqual([1000n, 2]);
+    expect(round([123456n, 2], undefined, "ROUND_DOWN")).toEqual([123400n, 2]);
+    expect(round([123449n, 2], undefined, "ROUND_DOWN")).toEqual([123400n, 2]);
+    expect(round([123450n, 2], undefined, "ROUND_DOWN")).toEqual([123400n, 2]);
+    expect(
+      round([1234555555555555555555n, 18], undefined, "ROUND_DOWN"),
+    ).toEqual([1234000000000000000000n, 18]);
+    expect(
+      round([1234499999999999999999n, 18], undefined, "ROUND_DOWN"),
+    ).toEqual([1234000000000000000000n, 18]);
+    expect(
+      round([1234499999999999999999n, 18], 2, "ROUND_DOWN"),
     ).toEqual([123400n, 2]);
   });
 });

--- a/test/all.test.ts
+++ b/test/all.test.ts
@@ -53,12 +53,22 @@ describe("setValueDecimals()", () => {
   it("rounds decimals when decreasing", () => {
     expect(setValueDecimals(123456n, -2)).toBe(1235n);
     expect(setValueDecimals(123456n, -6)).toBe(0n);
-  });
-  it("doesn’t round decimals when specified", () => {
-    expect(setValueDecimals(123456n, -2, { round: false })).toBe(1234n);
+    expect(setValueDecimals(-123456n, -2)).toBe(-1235n);
   });
   it("leaves decimals unchanged", () => {
     expect(setValueDecimals(123456n, 0)).toBe(123456n);
+  });
+  it("round decimals up when specified and decreasing", () => {
+    expect(setValueDecimals(1234n, -2, { round: "ROUND_UP" })).toBe(13n);
+    expect(setValueDecimals(123456n, -2, { round: "ROUND_UP" })).toBe(1235n);
+    expect(setValueDecimals(-1234n, -2, { round: "ROUND_UP" })).toBe(-12n);
+    expect(setValueDecimals(-123456n, -2, { round: "ROUND_UP" })).toBe(-1234n);
+  });
+  it("round decimals down when specified and specified", () => {
+    expect(setValueDecimals(1234n, -2, { round: "ROUND_DOWN" })).toBe(12n);
+    expect(setValueDecimals(123456n, -2, { round: "ROUND_DOWN" })).toBe(1234n);
+    expect(setValueDecimals(-1234n, -2, { round: "ROUND_DOWN" })).toBe(-13n);
+    expect(setValueDecimals(-123456n, -2, { round: "ROUND_DOWN" })).toBe(-1235n);
   });
 });
 
@@ -174,7 +184,7 @@ describe("subtract()", () => {
 });
 
 describe("multiply()", () => {
-  it("multiplies positive values", () => {
+  it("multiplies positive values and round", () => {
     const a1 = [123456n, 2] as const;
     const a2 = [123456n, 4] as const;
     const result = [1524138n, 2] as const;
@@ -183,12 +193,44 @@ describe("multiply()", () => {
     expect(multiply(16.34, 14.4454)).toEqual([2360378n, 4]);
     expect(multiply(16.34, 14.4454, 3)).toEqual([236038n, 3]);
   });
-  it("multiplies negative values", () => {
+  it("multiplies positive values and round up", () => {
+    const a1 = [123456n, 2] as const;
+    const a2 = [123456n, 4] as const;
+    const result = [1524139n, 2] as const;
+    expect(multiply(a1, a2, result[1], "ROUND_UP")).toEqual(result);
+    expect(multiply(a2, a1, result[1], "ROUND_UP")).toEqual(result);
+    expect(multiply(16.34, 14.4454, undefined, "ROUND_UP")).toEqual([2360379n, 4]);
+    expect(multiply(16.34, 14.4454, 3, "ROUND_UP")).toEqual([236038n, 3]);
+  });
+  it("multiplies positive values and round down", () => {
+    const a1 = [123456n, 2] as const;
+    const a2 = [123456n, 4] as const;
+    const result = [1524138n, 2] as const;
+    expect(multiply(a1, a2, result[1], "ROUND_DOWN")).toEqual(result);
+    expect(multiply(a2, a1, result[1], "ROUND_DOWN")).toEqual(result);
+    expect(multiply(16.34, 14.4454, undefined, "ROUND_DOWN")).toEqual([2360378n, 4]);
+    expect(multiply(16.34, 14.4454, 3, "ROUND_DOWN")).toEqual([236037n, 3]);
+  });
+  it("multiplies negative values and round", () => {
     const a1 = [123456n, 2] as const;
     const a2 = [-123456n, 4] as const;
     const result = [-1524138n, 2] as const;
     expect(multiply(a1, a2, result[1])).toEqual(result);
     expect(multiply(a2, a1, result[1])).toEqual(result);
+  });
+  it("multiplies negative values and round up", () => {
+    const a1 = [123456n, 2] as const;
+    const a2 = [-123456n, 4] as const;
+    const result = [-1524138n, 2] as const;
+    expect(multiply(a1, a2, result[1], "ROUND_UP")).toEqual(result);
+    expect(multiply(a2, a1, result[1], "ROUND_UP")).toEqual(result);
+  });
+  it("multiplies negative values and round down", () => {
+    const a1 = [123456n, 2] as const;
+    const a2 = [-123456n, 4] as const;
+    const result = [-1524139n, 2] as const;
+    expect(multiply(a1, a2, result[1], "ROUND_DOWN")).toEqual(result);
+    expect(multiply(a2, a1, result[1], "ROUND_DOWN")).toEqual(result);
   });
   it("throws if decimals are negative", () => {
     expect(() => multiply([1n, -1], [1n, 1], 1)).toThrowError(
@@ -219,7 +261,7 @@ describe("multiply()", () => {
 });
 
 describe("divide()", () => {
-  it("divides positive values", () => {
+  it("divides positive values and round", () => {
     expect(divide([4n, 0], [2n, 0], 0)).toEqual([2n, 0]);
     expect(divide([123456n, 4], [300000000n, 8], 2)).toEqual([412n, 2]);
     expect(divide([123456n, 4], [300000000n, 8], 4)).toEqual([
@@ -232,6 +274,76 @@ describe("divide()", () => {
     ]);
     expect(divide(8, 2, 8)).toEqual([400000000n, 8]);
     expect(divide(16.342, 14.43)).toEqual([1133n, 3]);
+  });
+  it("divides positive values and round up", () => {
+    expect(divide([4n, 0], [2n, 0], 0, "ROUND_UP")).toEqual([2n, 0]);
+    expect(divide([123456n, 4], [300000000n, 8], 2, "ROUND_UP")).toEqual([412n, 2]);
+    expect(divide([123456n, 4], [300000000n, 8], 4, "ROUND_UP")).toEqual([
+      41152n,
+      4,
+    ]);
+    expect(divide([123456n, 4], [300000000n, 8], 5, "ROUND_UP")).toEqual([
+      411520n,
+      5,
+    ]);
+    expect(divide(8, 2, 8, "ROUND_UP")).toEqual([400000000n, 8]);
+    expect(divide(16.342, 14.43, undefined, "ROUND_UP")).toEqual([1133n, 3]);
+  });
+  it("divides positive values and round down", () => {
+    expect(divide([4n, 0], [2n, 0], 0, "ROUND_DOWN")).toEqual([2n, 0]);
+    expect(divide([123456n, 4], [300000000n, 8], 2, "ROUND_DOWN")).toEqual([411n, 2]);
+    expect(divide([123456n, 4], [300000000n, 8], 4, "ROUND_DOWN")).toEqual([
+      41152n,
+      4,
+    ]);
+    expect(divide([123456n, 4], [300000000n, 8], 5, "ROUND_DOWN")).toEqual([
+      411520n,
+      5,
+    ]);
+    expect(divide(8, 2, 8, "ROUND_DOWN")).toEqual([400000000n, 8]);
+    expect(divide(16.342, 14.43, undefined, "ROUND_DOWN")).toEqual([1132n, 3]);
+  });
+  it("divides negative values and round", () => {
+    expect(divide([-4n, 0], [2n, 0], 0)).toEqual([-2n, 0]);
+    expect(divide([123456n, 4], [-300000000n, 8], 2)).toEqual([-412n, 2]);
+    expect(divide([-123456n, 4], [300000000n, 8], 4)).toEqual([
+      -41152n,
+      4,
+    ]);
+    expect(divide([123456n, 4], [-300000000n, 8], 5)).toEqual([
+      -411520n,
+      5,
+    ]);
+    expect(divide(-8, 2, 8)).toEqual([-400000000n, 8]);
+    expect(divide(16.342, -14.43)).toEqual([-1133n, 3]);
+  });
+  it("divides negative values and round up", () => {
+    expect(divide([-4n, 0], [2n, 0], 0, "ROUND_UP")).toEqual([-2n, 0]);
+    expect(divide([123456n, 4], [-300000000n, 8], 2, "ROUND_UP")).toEqual([-411n, 2]);
+    expect(divide([-123456n, 4], [300000000n, 8], 4, "ROUND_UP")).toEqual([
+      -41152n,
+      4,
+    ]);
+    expect(divide([123456n, 4], [-300000000n, 8], 5, "ROUND_UP")).toEqual([
+      -411520n,
+      5,
+    ]);
+    expect(divide(-8, 2, 8, "ROUND_UP")).toEqual([-400000000n, 8]);
+    expect(divide(16.342, -14.43, undefined, "ROUND_UP")).toEqual([-1132n, 3]);
+  });
+  it("divides negative values and round down", () => {
+    expect(divide([-4n, 0], [2n, 0], 0, "ROUND_DOWN")).toEqual([-2n, 0]);
+    expect(divide([123456n, 4], [-300000000n, 8], 2, "ROUND_DOWN")).toEqual([-412n, 2]);
+    expect(divide([-123456n, 4], [300000000n, 8], 4, "ROUND_DOWN")).toEqual([
+      -41152n,
+      4,
+    ]);
+    expect(divide([123456n, 4], [-300000000n, 8], 5, "ROUND_DOWN")).toEqual([
+      -411520n,
+      5,
+    ]);
+    expect(divide(-8, 2, 8, "ROUND_DOWN")).toEqual([-400000000n, 8]);
+    expect(divide(16.342, -14.43, undefined, "ROUND_DOWN")).toEqual([-1133n, 3]);
   });
   it("throws if decimals are negative", () => {
     expect(() => divide([1n, -1], [1n, 1], 1)).toThrowError(
@@ -275,7 +387,7 @@ describe("remainder()", () => {
 });
 
 describe("divideAndRound()", () => {
-  it("works", () => {
+  it("rounds decimals", () => {
     expect(divideAndRound(1n, 1n)).toBe(1n);
     expect(divideAndRound(1n, 3n)).toBe(0n);
     expect(divideAndRound(20n, 2n)).toBe(10n);
@@ -283,6 +395,50 @@ describe("divideAndRound()", () => {
     expect(divideAndRound(20n, 6n)).toBe(3n);
     expect(divideAndRound(20n, 7n)).toBe(3n);
     expect(divideAndRound(15n, 2n)).toBe(8n);
+
+    expect(divideAndRound(-1n, 1n)).toBe(-1n);
+    expect(divideAndRound(1n, -3n)).toBe(0n);
+    expect(divideAndRound(-20n, 2n)).toBe(-10n);
+    expect(divideAndRound(20n, -3n)).toBe(-7n);
+    expect(divideAndRound(-20n, 6n)).toBe(-3n);
+    expect(divideAndRound(20n, -7n)).toBe(-3n);
+    expect(divideAndRound(-15n, 2n)).toBe(-8n);
+  });
+
+  it("rounds decimals up", () => {
+    expect(divideAndRound(1n, 1n, "ROUND_UP")).toBe(1n);
+    expect(divideAndRound(1n, 3n, "ROUND_UP")).toBe(1n);
+    expect(divideAndRound(20n, 2n, "ROUND_UP")).toBe(10n);
+    expect(divideAndRound(20n, 3n, "ROUND_UP")).toBe(7n);
+    expect(divideAndRound(20n, 6n, "ROUND_UP")).toBe(4n);
+    expect(divideAndRound(20n, 7n, "ROUND_UP")).toBe(3n);
+    expect(divideAndRound(15n, 2n, "ROUND_UP")).toBe(8n);
+
+    expect(divideAndRound(-1n, 1n, "ROUND_UP")).toBe(-1n);
+    expect(divideAndRound(-1n, 3n, "ROUND_UP")).toBe(0n);
+    expect(divideAndRound(-20n, 2n, "ROUND_UP")).toBe(-10n);
+    expect(divideAndRound(-20n, 3n, "ROUND_UP")).toBe(-6n);
+    expect(divideAndRound(-20n, 6n, "ROUND_UP")).toBe(-3n);
+    expect(divideAndRound(-20n, 7n, "ROUND_UP")).toBe(-2n);
+    expect(divideAndRound(-15n, 2n, "ROUND_UP")).toBe(-7n);
+  });
+
+  it("rounds decimals down", () => {
+    expect(divideAndRound(1n, 1n, "ROUND_DOWN")).toBe(1n);
+    expect(divideAndRound(1n, 3n, "ROUND_DOWN")).toBe(0n);
+    expect(divideAndRound(20n, 2n, "ROUND_DOWN")).toBe(10n);
+    expect(divideAndRound(20n, 3n, "ROUND_DOWN")).toBe(6n);
+    expect(divideAndRound(20n, 6n, "ROUND_DOWN")).toBe(3n);
+    expect(divideAndRound(20n, 7n, "ROUND_DOWN")).toBe(2n);
+    expect(divideAndRound(15n, 2n, "ROUND_DOWN")).toBe(7n);
+
+    expect(divideAndRound(-1n, 1n, "ROUND_DOWN")).toBe(-1n);
+    expect(divideAndRound(1n, -3n, "ROUND_DOWN")).toBe(-1n);
+    expect(divideAndRound(-20n, 2n, "ROUND_DOWN")).toBe(-10n);
+    expect(divideAndRound(20n, -3n, "ROUND_DOWN")).toBe(-7n);
+    expect(divideAndRound(-20n, 6n, "ROUND_DOWN")).toBe(-4n);
+    expect(divideAndRound(20n, -7n, "ROUND_DOWN")).toBe(-3n);
+    expect(divideAndRound(-15n, 2n, "ROUND_DOWN")).toBe(-8n);
   });
 });
 

--- a/test/all.test.ts
+++ b/test/all.test.ts
@@ -203,19 +203,35 @@ describe("multiply()", () => {
     const a1 = [123456n, 2] as const;
     const a2 = [123456n, 4] as const;
     const result = [1524139n, 2] as const;
-    expect(multiply(a1, a2, result[1], "ROUND_UP")).toEqual(result);
-    expect(multiply(a2, a1, result[1], "ROUND_UP")).toEqual(result);
-    expect(multiply(16.34, 14.4454, undefined, "ROUND_UP")).toEqual([2360379n, 4]);
-    expect(multiply(16.34, 14.4454, 3, "ROUND_UP")).toEqual([236038n, 3]);
+    expect(
+      multiply(a1, a2, { decimals: result[1], rounding: "ROUND_UP" })
+    ).toEqual(result);
+    expect(
+      multiply(a2, a1, { decimals: result[1], rounding: "ROUND_UP" })
+    ).toEqual(result);
+    expect(
+      multiply(16.34, 14.4454, { rounding: "ROUND_UP" })
+    ).toEqual([2360379n, 4]);
+    expect(
+      multiply(16.34, 14.4454, { decimals: 3, rounding: "ROUND_UP" })
+    ).toEqual([236038n, 3]);
   });
   it("multiplies positive values and round down", () => {
     const a1 = [123456n, 2] as const;
     const a2 = [123456n, 4] as const;
     const result = [1524138n, 2] as const;
-    expect(multiply(a1, a2, result[1], "ROUND_DOWN")).toEqual(result);
-    expect(multiply(a2, a1, result[1], "ROUND_DOWN")).toEqual(result);
-    expect(multiply(16.34, 14.4454, undefined, "ROUND_DOWN")).toEqual([2360378n, 4]);
-    expect(multiply(16.34, 14.4454, 3, "ROUND_DOWN")).toEqual([236037n, 3]);
+    expect(
+      multiply(a1, a2, { decimals: result[1], rounding: "ROUND_DOWN" })
+    ).toEqual(result);
+    expect(
+      multiply(a2, a1, { decimals: result[1], rounding: "ROUND_DOWN" })
+    ).toEqual(result);
+    expect(
+      multiply(16.34, 14.4454, { rounding: "ROUND_DOWN" })
+    ).toEqual([2360378n, 4]);
+    expect(
+      multiply(16.34, 14.4454, { decimals: 3, rounding: "ROUND_DOWN" })
+    ).toEqual([236037n, 3]);
   });
   it("multiplies negative values and round", () => {
     const a1 = [123456n, 2] as const;
@@ -228,15 +244,23 @@ describe("multiply()", () => {
     const a1 = [123456n, 2] as const;
     const a2 = [-123456n, 4] as const;
     const result = [-1524138n, 2] as const;
-    expect(multiply(a1, a2, result[1], "ROUND_UP")).toEqual(result);
-    expect(multiply(a2, a1, result[1], "ROUND_UP")).toEqual(result);
+    expect(
+      multiply(a1, a2, { decimals: result[1], rounding: "ROUND_UP" })
+    ).toEqual(result);
+    expect(
+      multiply(a2, a1, { decimals: result[1], rounding: "ROUND_UP" })
+    ).toEqual(result);
   });
   it("multiplies negative values and round down", () => {
     const a1 = [123456n, 2] as const;
     const a2 = [-123456n, 4] as const;
     const result = [-1524139n, 2] as const;
-    expect(multiply(a1, a2, result[1], "ROUND_DOWN")).toEqual(result);
-    expect(multiply(a2, a1, result[1], "ROUND_DOWN")).toEqual(result);
+    expect(
+      multiply(a1, a2, { decimals: result[1], rounding: "ROUND_DOWN" })
+    ).toEqual(result);
+    expect(
+      multiply(a2, a1, { decimals: result[1], rounding: "ROUND_DOWN" })
+    ).toEqual(result);
   });
   it("throws if decimals are negative", () => {
     expect(() => multiply([1n, -1], [1n, 1], 1)).toThrowError(
@@ -282,32 +306,40 @@ describe("divide()", () => {
     expect(divide(16.342, 14.43)).toEqual([1133n, 3]);
   });
   it("divides positive values and round up", () => {
-    expect(divide([4n, 0], [2n, 0], 0, "ROUND_UP")).toEqual([2n, 0]);
-    expect(divide([123456n, 4], [300000000n, 8], 2, "ROUND_UP")).toEqual([412n, 2]);
-    expect(divide([123456n, 4], [300000000n, 8], 4, "ROUND_UP")).toEqual([
-      41152n,
-      4,
-    ]);
-    expect(divide([123456n, 4], [300000000n, 8], 5, "ROUND_UP")).toEqual([
-      411520n,
-      5,
-    ]);
-    expect(divide(8, 2, 8, "ROUND_UP")).toEqual([400000000n, 8]);
-    expect(divide(16.342, 14.43, undefined, "ROUND_UP")).toEqual([1133n, 3]);
+    expect(
+      divide([4n, 0], [2n, 0], { decimals: 0, rounding: "ROUND_UP" })
+    ).toEqual([2n, 0]);
+    expect(
+      divide([123456n, 4], [300000000n, 8], { decimals: 2, rounding: "ROUND_UP" })
+    ).toEqual([412n, 2]);
+    expect(
+      divide([123456n, 4], [300000000n, 8], { decimals: 4, rounding: "ROUND_UP" })
+    ).toEqual([41152n, 4]);
+    expect(
+      divide([123456n, 4], [300000000n, 8], { decimals: 5, rounding: "ROUND_UP" })
+    ).toEqual([411520n, 5]);
+    expect(
+      divide(8, 2, { decimals: 8, rounding: "ROUND_UP" })
+    ).toEqual([400000000n, 8]);
+    expect(divide(16.342, 14.43, { rounding: "ROUND_UP" })).toEqual([1133n, 3]);
   });
   it("divides positive values and round down", () => {
-    expect(divide([4n, 0], [2n, 0], 0, "ROUND_DOWN")).toEqual([2n, 0]);
-    expect(divide([123456n, 4], [300000000n, 8], 2, "ROUND_DOWN")).toEqual([411n, 2]);
-    expect(divide([123456n, 4], [300000000n, 8], 4, "ROUND_DOWN")).toEqual([
-      41152n,
-      4,
-    ]);
-    expect(divide([123456n, 4], [300000000n, 8], 5, "ROUND_DOWN")).toEqual([
-      411520n,
-      5,
-    ]);
-    expect(divide(8, 2, 8, "ROUND_DOWN")).toEqual([400000000n, 8]);
-    expect(divide(16.342, 14.43, undefined, "ROUND_DOWN")).toEqual([1132n, 3]);
+    expect(
+      divide([4n, 0], [2n, 0], { decimals: 0, rounding: "ROUND_DOWN" })
+    ).toEqual([2n, 0]);
+    expect(
+      divide([123456n, 4], [300000000n, 8], { decimals: 2, rounding: "ROUND_DOWN" })
+    ).toEqual([411n, 2]);
+    expect(
+      divide([123456n, 4], [300000000n, 8], { decimals: 4, rounding: "ROUND_DOWN" })
+    ).toEqual([41152n, 4]);
+    expect(
+      divide([123456n, 4], [300000000n, 8], { decimals: 5, rounding: "ROUND_DOWN" })
+    ).toEqual([411520n, 5]);
+    expect(
+      divide(8, 2, { decimals: 8, rounding: "ROUND_DOWN" })
+    ).toEqual([400000000n, 8]);
+    expect(divide(16.342, 14.43, { rounding: "ROUND_DOWN" })).toEqual([1132n, 3]);
   });
   it("divides negative values and round", () => {
     expect(divide([-4n, 0], [2n, 0], 0)).toEqual([-2n, 0]);
@@ -324,32 +356,40 @@ describe("divide()", () => {
     expect(divide(16.342, -14.43)).toEqual([-1133n, 3]);
   });
   it("divides negative values and round up", () => {
-    expect(divide([-4n, 0], [2n, 0], 0, "ROUND_UP")).toEqual([-2n, 0]);
-    expect(divide([123456n, 4], [-300000000n, 8], 2, "ROUND_UP")).toEqual([-411n, 2]);
-    expect(divide([-123456n, 4], [300000000n, 8], 4, "ROUND_UP")).toEqual([
-      -41152n,
-      4,
-    ]);
-    expect(divide([123456n, 4], [-300000000n, 8], 5, "ROUND_UP")).toEqual([
-      -411520n,
-      5,
-    ]);
-    expect(divide(-8, 2, 8, "ROUND_UP")).toEqual([-400000000n, 8]);
-    expect(divide(16.342, -14.43, undefined, "ROUND_UP")).toEqual([-1132n, 3]);
+    expect(
+      divide([-4n, 0], [2n, 0], { decimals: 0, rounding: "ROUND_UP"})
+    ).toEqual([-2n, 0]);
+    expect(
+      divide([123456n, 4], [-300000000n, 8], { decimals: 2, rounding: "ROUND_UP"})
+    ).toEqual([-411n, 2]);
+    expect(
+      divide([-123456n, 4], [300000000n, 8], { decimals: 4, rounding: "ROUND_UP"})
+    ).toEqual([-41152n, 4]);
+    expect(
+      divide([123456n, 4], [-300000000n, 8], { decimals: 5, rounding: "ROUND_UP"})
+    ).toEqual([-411520n, 5]);
+    expect(
+      divide(-8, 2, { decimals: 8, rounding: "ROUND_UP"})
+    ).toEqual([-400000000n, 8]);
+    expect(divide(16.342, -14.43, { rounding: "ROUND_UP"})).toEqual([-1132n, 3]);
   });
   it("divides negative values and round down", () => {
-    expect(divide([-4n, 0], [2n, 0], 0, "ROUND_DOWN")).toEqual([-2n, 0]);
-    expect(divide([123456n, 4], [-300000000n, 8], 2, "ROUND_DOWN")).toEqual([-412n, 2]);
-    expect(divide([-123456n, 4], [300000000n, 8], 4, "ROUND_DOWN")).toEqual([
-      -41152n,
-      4,
-    ]);
-    expect(divide([123456n, 4], [-300000000n, 8], 5, "ROUND_DOWN")).toEqual([
-      -411520n,
-      5,
-    ]);
-    expect(divide(-8, 2, 8, "ROUND_DOWN")).toEqual([-400000000n, 8]);
-    expect(divide(16.342, -14.43, undefined, "ROUND_DOWN")).toEqual([-1133n, 3]);
+    expect(
+      divide([-4n, 0], [2n, 0], { decimals: 0, rounding: "ROUND_DOWN"})
+    ).toEqual([-2n, 0]);
+    expect(
+      divide([123456n, 4], [-300000000n, 8], { decimals: 2, rounding: "ROUND_DOWN"})
+    ).toEqual([-412n, 2]);
+    expect(
+      divide([-123456n, 4], [300000000n, 8], { decimals: 4, rounding: "ROUND_DOWN"})
+    ).toEqual([-41152n, 4]);
+    expect(
+      divide([123456n, 4], [-300000000n, 8], { decimals: 5, rounding: "ROUND_DOWN"})
+    ).toEqual([-411520n, 5]);
+    expect(
+      divide(-8, 2, { decimals: 8, rounding: "ROUND_DOWN"})
+    ).toEqual([-400000000n, 8]);
+    expect(divide(16.342, -14.43, { rounding: "ROUND_DOWN"})).toEqual([-1133n, 3]);
   });
   it("throws if decimals are negative", () => {
     expect(() => divide([1n, -1], [1n, 1], 1)).toThrowError(
@@ -495,34 +535,34 @@ describe("round()", () => {
   });
 
   it("rounds decimals up", () => {
-    expect(round([1000n, 2], undefined, "ROUND_UP")).toEqual([1000n, 2]);
-    expect(round([123456n, 2], undefined, "ROUND_UP")).toEqual([123500n, 2]);
-    expect(round([123449n, 2], undefined, "ROUND_UP")).toEqual([123500n, 2]);
-    expect(round([123450n, 2], undefined, "ROUND_UP")).toEqual([123500n, 2]);
+    expect(round([1000n, 2], { rounding: "ROUND_UP" })).toEqual([1000n, 2]);
+    expect(round([123456n, 2], { rounding: "ROUND_UP" })).toEqual([123500n, 2]);
+    expect(round([123449n, 2], { rounding: "ROUND_UP" })).toEqual([123500n, 2]);
+    expect(round([123450n, 2], { rounding: "ROUND_UP" })).toEqual([123500n, 2]);
     expect(
-      round([1234555555555555555555n, 18], undefined, "ROUND_UP"),
+      round([1234555555555555555555n, 18], { rounding: "ROUND_UP" }),
     ).toEqual([1235000000000000000000n, 18]);
     expect(
-      round([1234499999999999999999n, 18], undefined, "ROUND_UP"),
+      round([1234499999999999999999n, 18], { rounding: "ROUND_UP" }),
     ).toEqual([1235000000000000000000n, 18]);
     expect(
-      round([1234499999999999999999n, 18], 2, "ROUND_UP"),
+      round([1234499999999999999999n, 18], { decimals: 2, rounding: "ROUND_UP" }),
     ).toEqual([123500n, 2]);
   });
 
   it("rounds decimals down", () => {
-    expect(round([1000n, 2], undefined, "ROUND_DOWN")).toEqual([1000n, 2]);
-    expect(round([123456n, 2], undefined, "ROUND_DOWN")).toEqual([123400n, 2]);
-    expect(round([123449n, 2], undefined, "ROUND_DOWN")).toEqual([123400n, 2]);
-    expect(round([123450n, 2], undefined, "ROUND_DOWN")).toEqual([123400n, 2]);
+    expect(round([1000n, 2], { rounding: "ROUND_DOWN" })).toEqual([1000n, 2]);
+    expect(round([123456n, 2], { rounding: "ROUND_DOWN" })).toEqual([123400n, 2]);
+    expect(round([123449n, 2], { rounding: "ROUND_DOWN" })).toEqual([123400n, 2]);
+    expect(round([123450n, 2], { rounding: "ROUND_DOWN" })).toEqual([123400n, 2]);
     expect(
-      round([1234555555555555555555n, 18], undefined, "ROUND_DOWN"),
+      round([1234555555555555555555n, 18], { rounding: "ROUND_DOWN" }),
     ).toEqual([1234000000000000000000n, 18]);
     expect(
-      round([1234499999999999999999n, 18], undefined, "ROUND_DOWN"),
+      round([1234499999999999999999n, 18], { rounding: "ROUND_DOWN" }),
     ).toEqual([1234000000000000000000n, 18]);
     expect(
-      round([1234499999999999999999n, 18], 2, "ROUND_DOWN"),
+      round([1234499999999999999999n, 18], { decimals: 2, rounding: "ROUND_DOWN" }),
     ).toEqual([123400n, 2]);
   });
 });


### PR DESCRIPTION
The default behaviour for the `multiply` and `divide` operations was to `ROUND_HALF`. Added the possibility to specify whether to `ROUND_UP` or `ROUND_DOWN`. Rounding down is especially important as that is the typical behaviour in smart contract opcodes (EVM and non-EVM alike). 

Also fixed a bug in the `divideAndRound` function (which is called by many operations) when the divisor is negative. E.g.  `divideAndRound(-15n, 2n))` and `divideAndRound(15n, -2n)` yielded different results.

Updated docs with latest changes.

